### PR TITLE
definition and annotations for 'assessment'

### DIFF
--- a/terminology.tsv
+++ b/terminology.tsv
@@ -1,3 +1,3 @@
 oed ID	label	alternative term	definition	definition source	example of usage	term editor	"ontology term requester	term tracker item"	logical type	parent class
-	assessment								
+	assessment		The process of testing and documenting knowledge or skills based on previous instruction in order to refine and improve student learning.	https://en.wikipedia.org/wiki/Educational_assessment			https://github.com/hectorguzor/provisional_OntoEd/issues/2	subclass	process
 	curriculum								


### PR DESCRIPTION
This PR provides a provisional definition for 'assessment' in `terminology.tsv`. It also provides some annotations as indicated in #2. 