### PR TITLE
Add oed id's and 'dean role' to terminology

### DIFF
--- a/terminology.tsv
+++ b/terminology.tsv
@@ -1,3 +1,4 @@
 oed ID	label	alternative term	definition	definition source	example of usage	term editor	"ontology term requester	term tracker item"	logical type	parent class
 1000001	assessment								
 1000002	curriculum								
+1000003	dean role								

--- a/terminology.tsv
+++ b/terminology.tsv
@@ -1,3 +1,3 @@
 oed ID	label	alternative term	definition	definition source	example of usage	term editor	"ontology term requester	term tracker item"	logical type	parent class
-	assessment								
-	curriculum								
+1000001	assessment								
+1000002	curriculum								


### PR DESCRIPTION
This PR adds oed id's  and 'dean role' to `terminology.tsv` . This partially completes issues #2 and issue #7 